### PR TITLE
Install Sentry integration to all functions

### DIFF
--- a/function/distributor/main.go
+++ b/function/distributor/main.go
@@ -5,17 +5,29 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"time"
 
 	baselambda "github.com/aws/aws-lambda-go/lambda"
 	"github.com/aws/aws-sdk-go/aws/session"
 	lambdaapi "github.com/aws/aws-sdk-go/service/lambda"
 	s3api "github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-xray-sdk-go/xray"
+	"github.com/getsentry/sentry-go"
 
 	"github.com/dtan4/xlapse/service/lambda"
 	"github.com/dtan4/xlapse/service/s3"
 	"github.com/dtan4/xlapse/types"
 )
+
+var (
+	sentryEnabled = false
+)
+
+func init() {
+	if os.Getenv("SENTRY_DSN") != "" {
+		sentryEnabled = true
+	}
+}
 
 func HandleRequest(ctx context.Context) error {
 	bucket := os.Getenv("BUCKET")
@@ -26,7 +38,36 @@ func HandleRequest(ctx context.Context) error {
 	log.Printf("key: %q", key)
 	log.Printf("farn: %q", farn)
 
-	return do(ctx, bucket, key, farn)
+	if sentryEnabled {
+		if err := sentry.Init(sentry.ClientOptions{
+			Dsn: os.Getenv("SENTRY_DSN"),
+			Transport: &sentry.HTTPSyncTransport{
+				Timeout: 5 * time.Second,
+			},
+
+			// https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html#configuration-envvars-runtime
+			Release:    os.Getenv("AWS_LAMBDA_FUNCTION_VERSION"),
+			ServerName: os.Getenv("AWS_LAMBDA_FUNCTION_NAME"),
+
+			Debug: true,
+		}); err != nil {
+			return fmt.Errorf("cannot initialize Sentry client: %w", err)
+		}
+
+		sentry.ConfigureScope(func(scope *sentry.Scope) {
+			scope.SetTag("function", "distributor")
+		})
+	}
+
+	if err := do(ctx, bucket, key, farn); err != nil {
+		if sentryEnabled {
+			sentry.CaptureException(err)
+		}
+
+		return err
+	}
+
+	return nil
 }
 
 func main() {

--- a/function/distributor/main.go
+++ b/function/distributor/main.go
@@ -48,8 +48,6 @@ func HandleRequest(ctx context.Context) error {
 			// https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html#configuration-envvars-runtime
 			Release:    os.Getenv("AWS_LAMBDA_FUNCTION_VERSION"),
 			ServerName: os.Getenv("AWS_LAMBDA_FUNCTION_NAME"),
-
-			Debug: true,
 		}); err != nil {
 			return fmt.Errorf("cannot initialize Sentry client: %w", err)
 		}

--- a/function/downloader/main.go
+++ b/function/downloader/main.go
@@ -56,8 +56,6 @@ func HandleRequest(ctx context.Context, entry types.Entry) error {
 			// https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html#configuration-envvars-runtime
 			Release:    os.Getenv("AWS_LAMBDA_FUNCTION_VERSION"),
 			ServerName: os.Getenv("AWS_LAMBDA_FUNCTION_NAME"),
-
-			Debug: true,
 		}); err != nil {
 			return fmt.Errorf("cannot initialize Sentry client: %w", err)
 		}

--- a/function/gif-distributor/main.go
+++ b/function/gif-distributor/main.go
@@ -48,8 +48,6 @@ func HandleRequest(ctx context.Context) error {
 			// https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html#configuration-envvars-runtime
 			Release:    os.Getenv("AWS_LAMBDA_FUNCTION_VERSION"),
 			ServerName: os.Getenv("AWS_LAMBDA_FUNCTION_NAME"),
-
-			Debug: true,
 		}); err != nil {
 			return fmt.Errorf("cannot initialize Sentry client: %w", err)
 		}

--- a/function/gif-maker/main.go
+++ b/function/gif-maker/main.go
@@ -63,7 +63,7 @@ func HandleRequest(ctx context.Context, req types.GifRequest) error {
 		}
 
 		sentry.ConfigureScope(func(scope *sentry.Scope) {
-			scope.SetTag("function", "downloader")
+			scope.SetTag("function", "gif-maker")
 			// We can distinguish target images by bucket and key_prefix
 			scope.SetTag("bucket", req.Bucket)
 			scope.SetTag("key_prefix", req.KeyPrefix)

--- a/function/gif-maker/main.go
+++ b/function/gif-maker/main.go
@@ -5,13 +5,16 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 	"path/filepath"
 	"sort"
+	"time"
 
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/aws/aws-sdk-go/aws/session"
 	s3api "github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-xray-sdk-go/xray"
+	"github.com/getsentry/sentry-go"
 
 	"github.com/dtan4/xlapse/service/s3"
 	"github.com/dtan4/xlapse/types"
@@ -21,6 +24,16 @@ const (
 	defaultDelay   = 10 // 100ms per frame == 10fps
 	defaultGifName = "movie.gif"
 )
+
+var (
+	sentryEnabled = false
+)
+
+func init() {
+	if os.Getenv("SENTRY_DSN") != "" {
+		sentryEnabled = true
+	}
+}
 
 func main() {
 	lambda.Start(HandleRequest)
@@ -35,7 +48,41 @@ func HandleRequest(ctx context.Context, req types.GifRequest) error {
 
 	delay := defaultDelay
 
-	return do(ctx, req.Bucket, req.KeyPrefix, req.Year, req.Month, req.Day, delay)
+	if sentryEnabled {
+		if err := sentry.Init(sentry.ClientOptions{
+			Dsn: os.Getenv("SENTRY_DSN"),
+			Transport: &sentry.HTTPSyncTransport{
+				Timeout: 5 * time.Second,
+			},
+
+			// https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html#configuration-envvars-runtime
+			Release:    os.Getenv("AWS_LAMBDA_FUNCTION_VERSION"),
+			ServerName: os.Getenv("AWS_LAMBDA_FUNCTION_NAME"),
+
+			Debug: true,
+		}); err != nil {
+			return fmt.Errorf("cannot initialize Sentry client: %w", err)
+		}
+
+		sentry.ConfigureScope(func(scope *sentry.Scope) {
+			scope.SetTag("function", "downloader")
+			// We can distinguish target images by bucket and key_prefix
+			scope.SetTag("bucket", req.Bucket)
+			scope.SetTag("key_prefix", req.KeyPrefix)
+
+			scope.SetExtra("gif_request", req)
+		})
+	}
+
+	if err := do(ctx, req.Bucket, req.KeyPrefix, req.Year, req.Month, req.Day, delay); err != nil {
+		if sentryEnabled {
+			sentry.CaptureException(err)
+		}
+
+		return err
+	}
+
+	return nil
 }
 
 func do(ctx context.Context, bucket, keyPrefix string, year, month, day, delay int) error {

--- a/function/gif-maker/main.go
+++ b/function/gif-maker/main.go
@@ -58,8 +58,6 @@ func HandleRequest(ctx context.Context, req types.GifRequest) error {
 			// https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html#configuration-envvars-runtime
 			Release:    os.Getenv("AWS_LAMBDA_FUNCTION_VERSION"),
 			ServerName: os.Getenv("AWS_LAMBDA_FUNCTION_NAME"),
-
-			Debug: true,
 		}); err != nil {
 			return fmt.Errorf("cannot initialize Sentry client: %w", err)
 		}

--- a/template.yaml.sample
+++ b/template.yaml.sample
@@ -35,6 +35,8 @@ Resources:
           BUCKET: example-bucket
           KEY: example.csv
           DOWNLOADER_FUNCTION_ARN: !GetAtt RemoteFileToS3Downloader.Arn
+          # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/dynamic-references.html#dynamic-references-secretsmanager
+          SENTRY_DSN: !Sub '{{resolve:secretsmanager:Sentry:SecretString:dsn}}'
 
   RemoteFileToS3Downloader:
     Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
@@ -84,6 +86,8 @@ Resources:
           BUCKET: example-bucket
           KEY: example.csv
           GIF_MAKER_FUNCTION_ARN: !GetAtt RemoteFileToS3GifMaker.Arn
+          # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/dynamic-references.html#dynamic-references-secretsmanager
+          SENTRY_DSN: !Sub '{{resolve:secretsmanager:Sentry:SecretString:dsn}}'
 
   RemoteFileToS3GifMaker:
     Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
@@ -104,3 +108,7 @@ Resources:
                 - "s3:PutObject"
                 - "s3:PutObjectAcl"
               Resource: "*"
+      Environment:
+        Variables:
+          # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/dynamic-references.html#dynamic-references-secretsmanager
+          SENTRY_DSN: !Sub '{{resolve:secretsmanager:Sentry:SecretString:dsn}}'


### PR DESCRIPTION
## WHAT

- Install Sentry integration to all functions (distributor, gif-distributor, gif-maker) 
- Disable Sentry debug mode

## WHY

from https://github.com/dtan4/xlapse/issues/20

Currently, there is no way to track errors (server is unavailable, etc) in real time, except checking error logs at CloudWatch Logs. It's inconvenient to me.

Sentry with downloader function works well at https://github.com/dtan4/xlapse/pull/25