### PR TITLE
Embed version string in binaries, logs, and Sentry release metadata

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,6 +8,8 @@ builds:
 - id: distributor
   dir: function/distributor
   binary: xlapse-distributor
+  ldflags:
+  - "-s -w -X github.com/dtan4/xlapse/version.Version={{.Version}} -X github.com/dtan4/xlapse/version.Commit={{.Commit}} -X github.com/dtan4/xlapse/version.Date={{.Date}}"
   env:
   - CGO_ENABLED=0
   goos:
@@ -17,6 +19,8 @@ builds:
 - id: downloader
   dir: function/downloader
   binary: xlapse-downloader
+  ldflags:
+  - "-s -w -X github.com/dtan4/xlapse/version.Version={{.Version}} -X github.com/dtan4/xlapse/version.Commit={{.Commit}} -X github.com/dtan4/xlapse/version.Date={{.Date}}"
   env:
   - CGO_ENABLED=0
   goos:
@@ -26,6 +30,8 @@ builds:
 - id: gif-distributor
   dir: function/gif-distributor
   binary: xlapse-gif-distributor
+  ldflags:
+  - "-s -w -X github.com/dtan4/xlapse/version.Version={{.Version}} -X github.com/dtan4/xlapse/version.Commit={{.Commit}} -X github.com/dtan4/xlapse/version.Date={{.Date}}"
   env:
   - CGO_ENABLED=0
   goos:
@@ -35,6 +41,8 @@ builds:
 - id: gif-maker
   dir: function/gif-maker
   binary: xlapse-gif-maker
+  ldflags:
+  - "-s -w -X github.com/dtan4/xlapse/version.Version={{.Version}} -X github.com/dtan4/xlapse/version.Commit={{.Commit}} -X github.com/dtan4/xlapse/version.Date={{.Date}}"
   env:
   - CGO_ENABLED=0
   goos:

--- a/function/distributor/main.go
+++ b/function/distributor/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/dtan4/xlapse/service/lambda"
 	"github.com/dtan4/xlapse/service/s3"
 	"github.com/dtan4/xlapse/types"
+	"github.com/dtan4/xlapse/version"
 )
 
 var (
@@ -33,6 +34,10 @@ func HandleRequest(ctx context.Context) error {
 	bucket := os.Getenv("BUCKET")
 	key := os.Getenv("KEY")
 	farn := os.Getenv("DOWNLOADER_FUNCTION_ARN")
+
+	log.Printf("function version: %q", version.Version)
+	log.Printf("function built commit: %q", version.Commit)
+	log.Printf("function built date: %q", version.Date)
 
 	log.Printf("bucket: %q", bucket)
 	log.Printf("key: %q", key)

--- a/function/distributor/main.go
+++ b/function/distributor/main.go
@@ -50,8 +50,8 @@ func HandleRequest(ctx context.Context) error {
 				Timeout: 5 * time.Second,
 			},
 
+			Release: version.Version,
 			// https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html#configuration-envvars-runtime
-			Release:    os.Getenv("AWS_LAMBDA_FUNCTION_VERSION"),
 			ServerName: os.Getenv("AWS_LAMBDA_FUNCTION_NAME"),
 		}); err != nil {
 			return fmt.Errorf("cannot initialize Sentry client: %w", err)

--- a/function/downloader/main.go
+++ b/function/downloader/main.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/dtan4/xlapse/service/s3"
 	"github.com/dtan4/xlapse/types"
+	"github.com/dtan4/xlapse/version"
 )
 
 const (
@@ -40,6 +41,10 @@ func HandleRequest(ctx context.Context, entry types.Entry) error {
 	if timezone == "" {
 		timezone = defaultTimezone
 	}
+
+	log.Printf("function version: %q", version.Version)
+	log.Printf("function built commit: %q", version.Commit)
+	log.Printf("function built date: %q", version.Date)
 
 	log.Printf("url: %q", entry.URL)
 	log.Printf("bucket: %q", entry.Bucket)

--- a/function/downloader/main.go
+++ b/function/downloader/main.go
@@ -58,8 +58,8 @@ func HandleRequest(ctx context.Context, entry types.Entry) error {
 				Timeout: 5 * time.Second,
 			},
 
+			Release: version.Version,
 			// https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html#configuration-envvars-runtime
-			Release:    os.Getenv("AWS_LAMBDA_FUNCTION_VERSION"),
 			ServerName: os.Getenv("AWS_LAMBDA_FUNCTION_NAME"),
 		}); err != nil {
 			return fmt.Errorf("cannot initialize Sentry client: %w", err)

--- a/function/gif-distributor/main.go
+++ b/function/gif-distributor/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/dtan4/xlapse/service/lambda"
 	"github.com/dtan4/xlapse/service/s3"
 	"github.com/dtan4/xlapse/types"
+	"github.com/dtan4/xlapse/version"
 )
 
 var (
@@ -33,6 +34,10 @@ func HandleRequest(ctx context.Context) error {
 	bucket := os.Getenv("BUCKET")
 	key := os.Getenv("KEY")
 	farn := os.Getenv("GIF_MAKER_FUNCTION_ARN")
+
+	log.Printf("function version: %q", version.Version)
+	log.Printf("function built commit: %q", version.Commit)
+	log.Printf("function built date: %q", version.Date)
 
 	log.Printf("bucket: %q", bucket)
 	log.Printf("key: %q", key)

--- a/function/gif-distributor/main.go
+++ b/function/gif-distributor/main.go
@@ -50,8 +50,8 @@ func HandleRequest(ctx context.Context) error {
 				Timeout: 5 * time.Second,
 			},
 
+			Release: version.Version,
 			// https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html#configuration-envvars-runtime
-			Release:    os.Getenv("AWS_LAMBDA_FUNCTION_VERSION"),
 			ServerName: os.Getenv("AWS_LAMBDA_FUNCTION_NAME"),
 		}); err != nil {
 			return fmt.Errorf("cannot initialize Sentry client: %w", err)

--- a/function/gif-maker/main.go
+++ b/function/gif-maker/main.go
@@ -60,8 +60,8 @@ func HandleRequest(ctx context.Context, req types.GifRequest) error {
 				Timeout: 5 * time.Second,
 			},
 
+			Release: version.Version,
 			// https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html#configuration-envvars-runtime
-			Release:    os.Getenv("AWS_LAMBDA_FUNCTION_VERSION"),
 			ServerName: os.Getenv("AWS_LAMBDA_FUNCTION_NAME"),
 		}); err != nil {
 			return fmt.Errorf("cannot initialize Sentry client: %w", err)

--- a/function/gif-maker/main.go
+++ b/function/gif-maker/main.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/dtan4/xlapse/service/s3"
 	"github.com/dtan4/xlapse/types"
+	"github.com/dtan4/xlapse/version"
 )
 
 const (
@@ -40,6 +41,10 @@ func main() {
 }
 
 func HandleRequest(ctx context.Context, req types.GifRequest) error {
+	log.Printf("function version: %q", version.Version)
+	log.Printf("function built commit: %q", version.Commit)
+	log.Printf("function built date: %q", version.Date)
+
 	log.Printf("bucket: %q", req.Bucket)
 	log.Printf("key prefix: %q", req.KeyPrefix)
 	log.Printf("year: %d", req.Year)

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,7 @@
+package version
+
+var (
+	Version string
+	Commit  string
+	Date    string
+)


### PR DESCRIPTION
## WHAT

Embed version string in binaries, function logs, and Sentry release metadata

## WHY

from https://github.com/dtan4/xlapse/issues/20

To track errors with proper revision, we should use binary version (= Git tag in this repository).