### PR TITLE
Use preinstalled Bazel

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,12 +17,6 @@ jobs:
         with:
           path: "/home/runner/.cache/bazel"
           key: bazel
-      - name: Install Bazelisk
-        run: |
-          curl -LO "https://github.com/bazelbuild/bazelisk/releases/download/v1.10.1/bazelisk-linux-amd64"
-          mkdir -p "${GITHUB_WORKSPACE}/bin/"
-          mv bazelisk-linux-amd64 "${GITHUB_WORKSPACE}/bin/bazel"
-          chmod +x "${GITHUB_WORKSPACE}/bin/bazel"
       - name: Run tests
         run: |
-          "${GITHUB_WORKSPACE}/bin/bazel" test //...
+          make test


### PR DESCRIPTION
GitHub-hosted runner already has Bazel
https://github.com/actions/virtual-environments/blob/631fc5df2fb8965a7c5b67d230714367df40e324/images/linux/Ubuntu2004-Readme.md

![image](https://user-images.githubusercontent.com/680124/163421616-0a995715-fc2b-45ae-a9e6-c90eea18c8d4.png)
